### PR TITLE
Gemma를 이용한 솔루션 제시 로직 추가

### DIFF
--- a/src/api/geminiApi.ts
+++ b/src/api/geminiApi.ts
@@ -1,61 +1,108 @@
-import {GoogleGenAI,Type } from '@google/genai';
-import { GeminiResponse } from '../types/response';
+import { GoogleGenAI, Type } from "@google/genai";
+import { GeminiResponse } from "../types/response";
 const GEMINI_API_KEY = import.meta.env.VITE_GEMINI_API_KEY;
 
-const ai = new GoogleGenAI({apiKey: GEMINI_API_KEY});
+const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
 
-export const getGeminiSolution = async (newsContents: string): Promise<GeminiResponse> => {
-  const response = await ai.models.generateContent({
-    model: 'gemini-1.5-flash',
+const getSolutionWithGemma = async (newsContents: string): Promise<string> => {
+  const model = ai.models.generateContent({
+    model: "gemma-3-27b-it",
     contents: `
-You are a news-analysis assistant. 
+      You are a news-analysis assistant. 
 
-INPUT:
-  - The variable \`newsContents\` contains the full text of a news article.
+      INPUT:
+        - The provided text contains a news article.
 
-TASK:
-  1. Read the article and think of a concise "solution"—that is, a clear recommendation, next action, or summary of how to address the issues described.
-  2. Identify up to 3 existing, real-world news URLs that are directly related to the topic of this article. These should be valid links (e.g. starting with https://) to reputable news sources.
+      TASK:
+        - Read the article and think of a concise "solution"—that is, a clear recommendation, next action, or summary of how to address the issues described.
+        - Be practical, specific, and actionable in your recommendation.
+        - Keep your solution concise (3-4 sentences).
 
-OUTPUT FORMAT (strict JSON, no additional keys or prose):
-\`\`\`json
-{
-  "solution": "…",             // recommendation or summary
-  "relatedNews": [             // array of up to 3 URL strings
-    "https://…",
-    "https://…"
-  ]
-}
-\`\`\`
+      Based on the following article text, provide ONLY your solution recommendation:
 
-Now produce only the JSON object described above, with the field “solution” and “relatedNews”, based on the following article text:
+      \`\`\`
+      ${newsContents}
+      \`\`\`
+    `,
+  });
 
-\`\`\`
-${newsContents}
-\`\`\`
+  const response = await model;
+  return response.text?.trim() || "No solution found.";
+};
+
+const getRelatedNewsWithGemini = async (
+  newsContents: string
+): Promise<string[]> => {
+  const model = ai.models.generateContent({
+    model: "gemini-2.0-flash",
+    contents: `
+      You are a news-analysis assistant. 
+
+      INPUT:
+        - The provided text contains a news article.
+
+      TASK:
+        - Identify up to 3 existing, real-world news URLs that are directly related to the topic of this article.
+        - These should be valid links (e.g. starting with https://) to reputable news sources.
+
+      OUTPUT FORMAT (strict JSON, no additional keys or prose):
+      \`\`\`json
+      {
+        "relatedNews": [             // array of up to 3 URL strings
+          "https://…",
+          "https://…"
+        ]
+      }
+      \`\`\`
+
+      Now produce only the JSON object described above with the field "relatedNews", based on the following article text:
+
+      \`\`\`
+      ${newsContents}
+      \`\`\`
     `,
     config: {
       responseMimeType: "application/json",
       responseSchema: {
         type: Type.OBJECT,
         properties: {
-          solution: {
-            type: Type.STRING,
-            description: "Concise recommendation or next-action based on the article",
-          },
           relatedNews: {
             type: Type.ARRAY,
             items: {
               type: Type.STRING,
-              description: "List of up to 3 real news URLs related to the topic",
+              description:
+                "List of up to 3 real news URLs related to the topic",
             },
           },
         },
-        required: ["solution", "relatedNews"],
+        required: ["relatedNews"],
       },
     },
   });
-  const parsedResponse = JSON.parse(response.text || "[]") 
-  return parsedResponse;
+
+  const response = await model;
+  const parsedResponse = JSON.parse(response.text || '{"relatedNews":[]}');
+  return parsedResponse.relatedNews || [];
 };
 
+export const getGeminiSolution = async (
+  newsContents: string
+): Promise<GeminiResponse> => {
+  try {
+    const [solution, relatedNews] = await Promise.all([
+      getSolutionWithGemma(newsContents),
+      getRelatedNewsWithGemini(newsContents),
+    ]);
+
+    return {
+      solution,
+      relatedNews,
+    };
+  } catch (error) {
+    console.error("Gemini API error:", error);
+    return {
+      solution: "Error retrieving solution",
+      relatedNews: [],
+    };
+  }
+};

--- a/src/api/geminiApi.ts
+++ b/src/api/geminiApi.ts
@@ -36,26 +36,29 @@ const getRelatedNewsWithGemini = async (
   const model = ai.models.generateContent({
     model: "gemini-2.0-flash",
     contents: `
-      You are a news-analysis assistant. 
+      You are a news-analysis assistant with access to accurate information.
 
       INPUT:
         - The provided text contains a news article.
 
       TASK:
-        - Identify up to 3 existing, real-world news URLs that are directly related to the topic of this article.
-        - These should be valid links (e.g. starting with https://) to reputable news sources.
+        - Identify up to 3 REAL, EXISTING news URLs that are directly related to the topic of this article.
+        - ONLY include URLs that you are CERTAIN exist. Do NOT invent or guess URLs.
+        - If you're not sure about the exact URL, provide the homepage URL of the reputable news source instead.
+        - Prefer major news websites with predictable URL structures like bbc.com, cnn.com, reuters.com, etc.
+        - DO NOT provide URLs to non-existent pages.
 
-      OUTPUT FORMAT (strict JSON, no additional keys or prose):
+      OUTPUT FORMAT (strict JSON):
       \`\`\`json
       {
-        "relatedNews": [             // array of up to 3 URL strings
-          "https://…",
-          "https://…"
+        "relatedNews": [
+          "https://www.example.com/real-article-path",
+          "https://www.anothersource.com/real-news-story"
         ]
       }
       \`\`\`
 
-      Now produce only the JSON object described above with the field "relatedNews", based on the following article text:
+      Based on the following article text, provide ONLY real, existing news URLs:
 
       \`\`\`
       ${newsContents}

--- a/src/components/news/NewsContents.tsx
+++ b/src/components/news/NewsContents.tsx
@@ -2,8 +2,6 @@ import styled from "styled-components";
 import { colFlex, rowFlex } from "../../styles/flexStyles";
 import theme from "../../styles/theme";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { getGeminiSolution } from "../../api/geminiApi";
 import NewsSideBar from "./NewsSideBar";
 
 interface NewsContentsProps {
@@ -21,23 +19,6 @@ const NewsContents = ({ newsData }: NewsContentsProps) => {
     newsBody,
     newsDate,
   } = newsData;
-  const [solution, setSolution] = useState<string>("");
-  const [relatedNews, setRelatedNews] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    setIsLoading(true);
-    getGeminiSolution(newsBody)
-      .then((data) => {
-        setSolution(data.solution);
-        setRelatedNews(data.relatedNews);
-        setIsLoading(false);
-      })
-      .catch((error) => {
-        console.error("Error fetching Gemini solution:", error);
-        setIsLoading(false);
-      });
-  }, [newsBody]);
 
   return (
     <PageLayout>
@@ -62,12 +43,7 @@ const NewsContents = ({ newsData }: NewsContentsProps) => {
         {newsImageUrl && <NewsImage src={newsImageUrl} alt={newsTitle} />}{" "}
         <MainContent>{newsBody}</MainContent>
       </Container>
-      <NewsSideBar
-        newsUrl={newsUrl}
-        isLoading={isLoading}
-        solution={solution}
-        relatedNews={relatedNews}
-      />
+      <NewsSideBar newsUrl={newsUrl} newsBody={newsBody} />
     </PageLayout>
   );
 };

--- a/src/components/news/NewsSideBar.tsx
+++ b/src/components/news/NewsSideBar.tsx
@@ -1,21 +1,35 @@
 import styled from "styled-components";
 import theme from "../../styles/theme";
 import { colFlex } from "../../styles/flexStyles";
+import { useEffect, useState } from "react";
+import { getGeminiSolution } from "../../api/geminiApi";
 
 interface NewsSideBarProps {
   newsUrl: string;
-  isLoading: boolean;
-  solution: string;
-  relatedNews: string[];
+  newsBody: string;
 }
 
-const NewsSideBar = ({
-  newsUrl,
-  isLoading,
-  solution,
-  relatedNews,
-}: NewsSideBarProps) => {
+const NewsSideBar = ({ newsUrl, newsBody }: NewsSideBarProps) => {
+  const [solution, setSolution] = useState<string>("");
+  const [relatedNews, setRelatedNews] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
   const hasRelatedNews = relatedNews && relatedNews.length > 0;
+
+  useEffect(() => {
+    setIsLoading(true);
+    getGeminiSolution(newsBody)
+      .then((data) => {
+        setSolution(data.solution);
+        setRelatedNews(data.relatedNews);
+      })
+      .catch((error) => {
+        console.error("Error fetching Gemini solution:", error);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [newsBody]);
 
   return (
     <Container>
@@ -37,7 +51,7 @@ const NewsSideBar = ({
       ) : (
         solution && (
           <SolutionContainer>
-            <SolutionHeader>Proposed Solutions (by Gemini)</SolutionHeader>
+            <SolutionHeader>Proposed Solutions (by Gemma)</SolutionHeader>
             <SolutionContent>{solution}</SolutionContent>
           </SolutionContainer>
         )


### PR DESCRIPTION
## 구현 사항
<img width="1039" alt="스크린샷 2025-05-16 오전 12 31 04" src="https://github.com/user-attachments/assets/93187432-9daf-4662-a9be-b4c594ddb314" />

- 뉴스 솔루션을 제시하는 부분을 Gemma로 변경했습니다.
- gemini 2.0 flash와 gemma-3-27b-it 모델을 이용했습니다.

## 🚀 로직 설명 및 코드 설명

```ts
   const [solution, relatedNews] = await Promise.all([
      getSolutionWithGemma(newsContents),
      getRelatedNewsWithGemini(newsContents),
    ]);

    return {
      solution,
      relatedNews,
    };
```
- 솔루션을 제시하는 요청과 URL을 제시하는 요청을 `Promise.all()`로 병렬 처리하여 성능을 유지하고자 했습니다.

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 지구본 로직이 너무 무거워서 뉴스 페이지로 바로 이동하지 못하는 이슈가 있습니다..ㅠ
