### PR TITLE
#49: 인터랙티브 기후 애니메이션 추가 및 뉴스 상세 페이지 레이아웃 개선

### DIFF
--- a/src/components/animation/DroughtAnimation.tsx
+++ b/src/components/animation/DroughtAnimation.tsx
@@ -56,6 +56,7 @@ const DroughtAnimation = () => {
     controls.maxPolarAngle = Math.PI / 2.2;
     controls.minDistance = 8;
     controls.maxDistance = 35;
+    controls.enableZoom = false;
 
     // Lighting
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
@@ -544,7 +545,7 @@ const DroughtAnimation = () => {
 
 const Container = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
   position: relative;
   overflow: hidden;
   cursor: pointer;

--- a/src/components/animation/EarthquakeAnimation.tsx
+++ b/src/components/animation/EarthquakeAnimation.tsx
@@ -1,0 +1,408 @@
+import { useEffect, useRef } from "react";
+import styled from "styled-components";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+
+// Performance detection
+const detectDevicePerformance = () => {
+  const canvas = document.createElement("canvas");
+  const gl = canvas.getContext("webgl") as WebGLRenderingContext;
+  if (!gl) return "LOW";
+
+  const renderer = gl.getParameter(gl.RENDERER) as string;
+  const isMobile =
+    /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    );
+  const isLowEndMobile =
+    isMobile &&
+    (navigator.hardwareConcurrency <= 4 || window.devicePixelRatio <= 2);
+
+  if (
+    isLowEndMobile ||
+    renderer.includes("Adreno 3") ||
+    renderer.includes("Mali-4")
+  ) {
+    return "LOW";
+  } else if (
+    isMobile ||
+    renderer.includes("Adreno 5") ||
+    renderer.includes("Mali-G")
+  ) {
+    return "MEDIUM";
+  }
+  return "HIGH";
+};
+
+const QUALITY = detectDevicePerformance();
+const QUALITY_SETTINGS = {
+  LOW: {
+    buildings: 20,
+    segments: 32,
+    shadowSize: 512,
+    dpr: 1,
+  },
+  MEDIUM: {
+    buildings: 50,
+    segments: 48,
+    shadowSize: 1024,
+    dpr: 1.5,
+  },
+  HIGH: {
+    buildings: 100,
+    segments: 64,
+    shadowSize: 2048,
+    dpr: 2,
+  },
+};
+
+const BUILDING_COUNT = QUALITY_SETTINGS[QUALITY].buildings;
+const SEGMENTS = QUALITY_SETTINGS[QUALITY].segments;
+const SHADOW_SIZE = QUALITY_SETTINGS[QUALITY].shadowSize;
+const DPR = QUALITY_SETTINGS[QUALITY].dpr;
+
+interface Shockwave {
+  x: number;
+  z: number;
+  startTime: number;
+  id: number;
+}
+
+const EarthquakeAnimation = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const shockwavesRef = useRef<Shockwave[]>([]);
+  const nextShockwaveId = useRef(0);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Scene Setup
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x2c3e50);
+    scene.fog = new THREE.Fog(0x2c3e50, 10, 50);
+
+    const camera = new THREE.PerspectiveCamera(
+      60,
+      containerRef.current.clientWidth / containerRef.current.clientHeight,
+      0.1,
+      1000
+    );
+    // 45-degree top-down view
+    camera.position.set(0, 15, 15);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: QUALITY !== "LOW",
+      powerPreference: "high-performance",
+    });
+    renderer.setSize(
+      containerRef.current.clientWidth,
+      containerRef.current.clientHeight
+    );
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, DPR));
+    renderer.shadowMap.enabled = QUALITY !== "LOW";
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    containerRef.current.appendChild(renderer.domElement);
+
+    // Controls
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enablePan = false;
+    controls.enableZoom = true;
+    controls.enableRotate = true;
+    controls.minDistance = 5;
+    controls.maxDistance = 40;
+    controls.maxPolarAngle = Math.PI / 2 - 0.1;
+    controls.target.set(0, 0, 0);
+
+    // Lights
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
+    scene.add(ambientLight);
+
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1.2);
+    dirLight.position.set(10, 20, 10);
+    dirLight.castShadow = QUALITY !== "LOW";
+    if (QUALITY !== "LOW") {
+      dirLight.shadow.mapSize.width = SHADOW_SIZE;
+      dirLight.shadow.mapSize.height = SHADOW_SIZE;
+      dirLight.shadow.camera.far = 50;
+      dirLight.shadow.camera.left = -20;
+      dirLight.shadow.camera.right = 20;
+      dirLight.shadow.camera.top = 20;
+      dirLight.shadow.camera.bottom = -20;
+    }
+    scene.add(dirLight);
+
+    // Ground
+    const groundGeo = new THREE.PlaneGeometry(50, 50, SEGMENTS, SEGMENTS);
+    // Store original positions for deformation
+    const originalPositions = groundGeo.attributes.position.array.slice();
+
+    const groundMat = new THREE.MeshStandardMaterial({
+      color: 0x34495e,
+      roughness: 0.8,
+      metalness: 0.2,
+      flatShading: true, // Low-poly look
+    });
+    const ground = new THREE.Mesh(groundGeo, groundMat);
+    ground.rotation.x = -Math.PI / 2;
+    ground.receiveShadow = true;
+    scene.add(ground);
+
+    // Buildings
+    const buildingGeo = new THREE.BoxGeometry(1, 1, 1);
+    const buildingMat = new THREE.MeshStandardMaterial({
+      color: 0x95a5a6,
+      roughness: 0.7,
+      metalness: 0.1,
+    });
+    const buildings = new THREE.InstancedMesh(
+      buildingGeo,
+      buildingMat,
+      BUILDING_COUNT
+    );
+    buildings.castShadow = QUALITY !== "LOW";
+    buildings.receiveShadow = QUALITY !== "LOW";
+
+    const dummy = new THREE.Object3D();
+    const buildingData: {
+      x: number;
+      z: number;
+      height: number;
+      scale: THREE.Vector3;
+    }[] = [];
+
+    // Generate buildings
+    const gridSize = Math.ceil(Math.sqrt(BUILDING_COUNT));
+    const spacing = 4;
+    const offset = (gridSize * spacing) / 2;
+
+    for (let i = 0; i < BUILDING_COUNT; i++) {
+      const row = Math.floor(i / gridSize);
+      const col = i % gridSize;
+
+      const x = col * spacing - offset + (Math.random() - 0.5) * 2;
+      const z = row * spacing - offset + (Math.random() - 0.5) * 2;
+
+      const height = 2 + Math.random() * 6;
+      const width = 1 + Math.random() * 1.5;
+      const depth = 1 + Math.random() * 1.5;
+
+      dummy.position.set(x, height / 2, z);
+      dummy.scale.set(width, height, depth);
+      dummy.updateMatrix();
+      buildings.setMatrixAt(i, dummy.matrix);
+
+      buildingData.push({
+        x,
+        z,
+        height,
+        scale: new THREE.Vector3(width, height, depth),
+      });
+    }
+    buildings.instanceMatrix.needsUpdate = true;
+    scene.add(buildings);
+
+    // Raycaster for interaction
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObject(ground);
+
+      if (intersects.length > 0) {
+        const point = intersects[0].point;
+        shockwavesRef.current.push({
+          x: point.x,
+          z: point.z,
+          startTime: performance.now(),
+          id: nextShockwaveId.current++,
+        });
+      }
+    };
+
+    renderer.domElement.addEventListener("pointerdown", handlePointerDown);
+
+    // Animation Loop
+    const animate = () => {
+      animationFrameRef.current = requestAnimationFrame(animate);
+      const now = performance.now();
+
+      // Filter out old shockwaves
+      shockwavesRef.current = shockwavesRef.current.filter(
+        (wave) => now - wave.startTime < 3000 // Lasts 3 seconds
+      );
+
+      // Update Ground
+      const positions = groundGeo.attributes.position.array as Float32Array;
+      const original = originalPositions as Float32Array;
+
+      for (let i = 0; i < positions.length; i += 3) {
+        const x = original[i];
+        const y = original[i + 1]; // Should be 0 initially (plane is flat)
+        // Wait, PlaneGeometry is X-Y. We rotated it -90 deg on X.
+        // So local (x, y, z) -> world (x, -z, y)? No.
+        // Local vertex (x, y, 0). Rotated -90 X -> (x, 0, -y).
+        // So world X = local X, world Z = -local Y.
+
+        // Let's just work with world coordinates.
+        // The loop iterates over vertices.
+        // Since we rotated the mesh, we need to be careful.
+        // Easier approach: Modify Z (height) of PlaneGeometry, which corresponds to Y in world space after rotation?
+        // No, PlaneGeometry is defined in XY plane. Z is normal.
+        // We rotated X by -90. So Plane's Z axis points to World +Y? No, World -Z?
+        // Let's simplify: We modify the 'Z' attribute of the geometry, which creates height variations.
+        // Since we rotated the mesh, the geometry's Z axis aligns with World Y (or -Y).
+
+        let displacement = 0;
+
+        // Calculate world position of this vertex
+        // Local: (x, y, 0)
+        // World: (x, 0, y) roughly (ignoring sign for now)
+
+        // Actually, let's just use the vertex coordinates as X and Z in world space logic
+        // because the plane is centered and covers XZ.
+        const vx = x;
+        const vz = -y; // Because of rotation
+
+        for (const wave of shockwavesRef.current) {
+          const dx = vx - wave.x;
+          const dz = vz - wave.z;
+          const dist = Math.sqrt(dx * dx + dz * dz);
+          const time = (now - wave.startTime) / 1000;
+
+          const waveSpeed = 10;
+          const waveDist = time * waveSpeed;
+          const waveWidth = 2;
+
+          if (Math.abs(dist - waveDist) < waveWidth) {
+            // Inside the wave ring
+            const intensity = 1 - time / 3; // Decay over time
+            const waveFunc =
+              Math.sin((dist - waveDist) * 2 * Math.PI) *
+              Math.exp(-Math.abs(dist - waveDist));
+            displacement += waveFunc * intensity * 0.5;
+          }
+        }
+
+        positions[i + 2] = displacement; // Modify Z (which is World Y)
+      }
+      groundGeo.attributes.position.needsUpdate = true;
+      groundGeo.computeVertexNormals(); // Recompute for lighting
+
+      // Update Buildings
+      for (let i = 0; i < BUILDING_COUNT; i++) {
+        const bData = buildingData[i];
+
+        let shakeX = 0;
+        let shakeZ = 0;
+        let shakeRot = 0;
+
+        for (const wave of shockwavesRef.current) {
+          const dx = bData.x - wave.x;
+          const dz = bData.z - wave.z;
+          const dist = Math.sqrt(dx * dx + dz * dz);
+          const time = (now - wave.startTime) / 1000;
+
+          const waveSpeed = 10;
+          const waveDist = time * waveSpeed;
+          const waveWidth = 3; // Buildings shake a bit longer
+
+          if (dist < waveDist + waveWidth && dist > waveDist - waveWidth) {
+            const intensity = (1 - time / 3) * 0.5;
+            shakeX += (Math.random() - 0.5) * intensity;
+            shakeZ += (Math.random() - 0.5) * intensity;
+            shakeRot += (Math.random() - 0.5) * intensity * 0.5;
+          }
+        }
+
+        dummy.position.set(
+          bData.x + shakeX,
+          bData.height / 2,
+          bData.z + shakeZ
+        );
+        dummy.rotation.set(shakeRot, shakeRot, shakeRot);
+        dummy.scale.copy(bData.scale);
+        dummy.updateMatrix();
+        buildings.setMatrixAt(i, dummy.matrix);
+      }
+      buildings.instanceMatrix.needsUpdate = true;
+
+      controls.update();
+      renderer.render(scene, camera);
+    };
+
+    animate();
+
+    // Resize Handler
+    const handleResize = () => {
+      if (!containerRef.current) return;
+      camera.aspect =
+        containerRef.current.clientWidth / containerRef.current.clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(
+        containerRef.current.clientWidth,
+        containerRef.current.clientHeight
+      );
+    };
+    window.addEventListener("resize", handleResize);
+
+    const container = containerRef.current;
+    // Cleanup
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      renderer.domElement.removeEventListener("pointerdown", handlePointerDown);
+
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+
+      controls.dispose();
+      groundGeo.dispose();
+      groundMat.dispose();
+      buildingGeo.dispose();
+      buildingMat.dispose();
+      renderer.dispose();
+
+      if (container && renderer.domElement) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return (
+    <Container ref={containerRef}>
+      <Instruction>땅을 클릭하여 지진 발생</Instruction>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+  cursor: crosshair;
+`;
+
+const Instruction = styled.div`
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.5);
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-family: sans-serif;
+  pointer-events: none;
+  z-index: 10;
+  font-weight: bold;
+`;
+
+export default EarthquakeAnimation;

--- a/src/components/animation/EarthquakeAnimation.tsx
+++ b/src/components/animation/EarthquakeAnimation.tsx
@@ -89,7 +89,7 @@ const EarthquakeAnimation = () => {
       1000
     );
     // 45-degree top-down view
-    camera.position.set(0, 15, 15);
+    camera.position.set(0, 20, 19);
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({
@@ -108,12 +108,12 @@ const EarthquakeAnimation = () => {
     // Controls
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enablePan = false;
-    controls.enableZoom = true;
     controls.enableRotate = true;
     controls.minDistance = 5;
     controls.maxDistance = 40;
     controls.maxPolarAngle = Math.PI / 2 - 0.1;
     controls.target.set(0, 0, 0);
+    controls.enableZoom = false;
 
     // Lights
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
@@ -384,7 +384,7 @@ const EarthquakeAnimation = () => {
 
 const Container = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
   position: relative;
   overflow: hidden;
   cursor: crosshair;

--- a/src/components/animation/FineDustAnimation.tsx
+++ b/src/components/animation/FineDustAnimation.tsx
@@ -84,7 +84,7 @@ const FineDustAnimation = () => {
       1000
     );
     // 45-degree top-down view
-    camera.position.set(0, 12, 12);
+    camera.position.set(15, 15, 20);
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({
@@ -111,6 +111,7 @@ const FineDustAnimation = () => {
     controls.maxDistance = 30;
     controls.maxPolarAngle = Math.PI / 2 - 0.1; // Don't go below ground
     controls.target.set(0, 0, 0);
+    controls.enableZoom = false;
 
     // Lights
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
@@ -401,7 +402,7 @@ const FineDustAnimation = () => {
 
 const Container = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
   position: relative;
   overflow: hidden;
   cursor: default;

--- a/src/components/animation/FineDustAnimation.tsx
+++ b/src/components/animation/FineDustAnimation.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useRef } from "react";
+import styled from "styled-components";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+
+// Performance detection and quality scaling
+const detectDevicePerformance = () => {
+  const canvas = document.createElement("canvas");
+  const gl = canvas.getContext("webgl") as WebGLRenderingContext;
+  if (!gl) return "LOW";
+
+  const renderer = gl.getParameter(gl.RENDERER) as string;
+  const isMobile =
+    /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    );
+  const isLowEndMobile =
+    isMobile &&
+    (navigator.hardwareConcurrency <= 4 || window.devicePixelRatio <= 2);
+
+  if (
+    isLowEndMobile ||
+    renderer.includes("Adreno 3") ||
+    renderer.includes("Mali-4")
+  ) {
+    return "LOW";
+  } else if (
+    isMobile ||
+    renderer.includes("Adreno 5") ||
+    renderer.includes("Mali-G")
+  ) {
+    return "MEDIUM";
+  }
+  return "HIGH";
+};
+
+const QUALITY = detectDevicePerformance();
+const QUALITY_SETTINGS = {
+  LOW: {
+    particles: 1000,
+    buildings: 15,
+    shadowSize: 512,
+    dpr: 1,
+  },
+  MEDIUM: {
+    particles: 3000,
+    buildings: 25,
+    shadowSize: 1024,
+    dpr: 1.5,
+  },
+  HIGH: {
+    particles: 5000,
+    buildings: 30,
+    shadowSize: 2048,
+    dpr: 2,
+  },
+};
+
+const PARTICLE_COUNT = QUALITY_SETTINGS[QUALITY].particles;
+const BUILDING_COUNT = QUALITY_SETTINGS[QUALITY].buildings;
+const SHADOW_SIZE = QUALITY_SETTINGS[QUALITY].shadowSize;
+const DPR = QUALITY_SETTINGS[QUALITY].dpr;
+
+const FineDustAnimation = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const mouseRef = useRef({ x: 0, y: 0, isDown: false });
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Scene Setup
+    const scene = new THREE.Scene();
+    // Fog color matching the original component
+    scene.fog = new THREE.FogExp2(0xc9b99b, 0.08);
+
+    const camera = new THREE.PerspectiveCamera(
+      60,
+      containerRef.current.clientWidth / containerRef.current.clientHeight,
+      0.1,
+      1000
+    );
+    camera.position.set(0, 5, 12);
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: QUALITY !== "LOW",
+      alpha: false,
+      powerPreference: "high-performance",
+      stencil: false,
+    });
+    renderer.setSize(
+      containerRef.current.clientWidth,
+      containerRef.current.clientHeight
+    );
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, DPR));
+    renderer.shadowMap.enabled = QUALITY !== "LOW";
+    containerRef.current.appendChild(renderer.domElement);
+
+    // Controls
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enablePan = true;
+    controls.enableZoom = true;
+    controls.enableRotate = true;
+    controls.minDistance = 3;
+    controls.maxDistance = 25;
+    controls.minPolarAngle = 0;
+    controls.maxPolarAngle = Math.PI / 2.2;
+
+    // Lights
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.3);
+    scene.add(ambientLight);
+
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1.8);
+    dirLight.position.set(10, 15, 8);
+    dirLight.castShadow = QUALITY !== "LOW";
+    if (QUALITY !== "LOW") {
+      dirLight.shadow.mapSize.width = SHADOW_SIZE;
+      dirLight.shadow.mapSize.height = SHADOW_SIZE;
+      dirLight.shadow.camera.far = 30;
+      dirLight.shadow.camera.left = -15;
+      dirLight.shadow.camera.right = 15;
+      dirLight.shadow.camera.top = 15;
+      dirLight.shadow.camera.bottom = -15;
+    }
+    scene.add(dirLight);
+
+    const hemiLight = new THREE.HemisphereLight(0xffeaa7, 0x636e72, 0.4);
+    scene.add(hemiLight);
+
+    // Ground
+    const groundGeo = new THREE.PlaneGeometry(50, 50);
+    const groundMat = new THREE.MeshStandardMaterial({
+      color: 0x8b7355,
+      roughness: 0.9,
+      metalness: 0.1,
+      transparent: true,
+      opacity: 0.8,
+    });
+    const ground = new THREE.Mesh(groundGeo, groundMat);
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = -1;
+    ground.receiveShadow = true;
+    scene.add(ground);
+
+    // Buildings (InstancedMesh)
+    const buildingGeo = new THREE.BoxGeometry(1, 1, 1);
+    const buildingMat = new THREE.MeshStandardMaterial({
+      roughness: 0.9,
+      metalness: 0.05,
+      transparent: true,
+      opacity: 0.85,
+      vertexColors: true,
+    });
+    const buildings = new THREE.InstancedMesh(
+      buildingGeo,
+      buildingMat,
+      BUILDING_COUNT
+    );
+    buildings.castShadow = QUALITY !== "LOW";
+    buildings.receiveShadow = QUALITY !== "LOW";
+
+    const dummy = new THREE.Object3D();
+    const colors = new Float32Array(BUILDING_COUNT * 3);
+
+    // Viewport approximation for building placement
+    // At z=0, visible width is approx: 2 * tan(30deg) * 12 ~= 13.8
+    const viewportWidth = 14;
+
+    for (let i = 0; i < BUILDING_COUNT; i++) {
+      const x = (Math.random() - 0.5) * viewportWidth * 0.7;
+      const z = (Math.random() - 0.5) * (viewportWidth / 5);
+      const height = 1 + Math.random() * 8;
+      const width = 0.5 + Math.random() * 1;
+      const depth = 0.5 + Math.random() * 1;
+      const darkness = 0.3 + Math.random() * 0.2;
+
+      dummy.position.set(x, height / 2, z);
+      dummy.rotation.set(0, 0, 0);
+      dummy.scale.set(width, height, depth);
+      dummy.updateMatrix();
+      buildings.setMatrixAt(i, dummy.matrix);
+
+      const color = new THREE.Color(
+        darkness * 0.5,
+        darkness * 0.5,
+        darkness * 0.6
+      );
+      colors[i * 3] = color.r;
+      colors[i * 3 + 1] = color.g;
+      colors[i * 3 + 2] = color.b;
+    }
+
+    buildings.instanceMatrix.needsUpdate = true;
+    buildings.geometry.setAttribute(
+      "color",
+      new THREE.InstancedBufferAttribute(colors, 3)
+    );
+    // Note: InstancedMesh standard material uses 'color' attribute for instance colors if vertexColors is true?
+    // Actually for InstancedMesh, we usually use instanceColor attribute.
+    // Let's fix this to match the original code which used 'instanceColor'
+    buildings.geometry.setAttribute(
+      "instanceColor",
+      new THREE.InstancedBufferAttribute(colors, 3)
+    );
+
+    scene.add(buildings);
+
+    // Dust Particles
+    const particleGeo = new THREE.BufferGeometry();
+    const particlePositions = new Float32Array(PARTICLE_COUNT * 3);
+    const particleData: { velocity: THREE.Vector3 }[] = [];
+
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const x = (Math.random() - 0.5) * viewportWidth * 1.2;
+      const y = Math.random() * 10;
+      const z = (Math.random() - 0.5) * viewportWidth * 1.2;
+
+      particlePositions[i * 3] = x;
+      particlePositions[i * 3 + 1] = y;
+      particlePositions[i * 3 + 2] = z;
+
+      particleData.push({
+        velocity: new THREE.Vector3(
+          (Math.random() - 0.5) * 0.01,
+          (Math.random() - 0.5) * 0.01,
+          (Math.random() - 0.5) * 0.01
+        ),
+      });
+    }
+
+    particleGeo.setAttribute(
+      "position",
+      new THREE.BufferAttribute(particlePositions, 3)
+    );
+
+    const particleMat = new THREE.PointsMaterial({
+      size: 0.03,
+      color: 0xd2c2a8,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.7,
+    });
+
+    const particles = new THREE.Points(particleGeo, particleMat);
+    scene.add(particles);
+
+    // Mouse Events
+    const handlePointerDown = (e: PointerEvent) => {
+      e.stopPropagation();
+      mouseRef.current.isDown = true;
+    };
+    const handlePointerUp = (e: PointerEvent) => {
+      e.stopPropagation();
+      mouseRef.current.isDown = false;
+    };
+    const handlePointerMove = (e: PointerEvent) => {
+      if ((e.buttons & 1) === 1) {
+        mouseRef.current.x = e.offsetX;
+        mouseRef.current.y = e.offsetY;
+      }
+    };
+    const handlePointerLeave = () => {
+      mouseRef.current.isDown = false;
+    };
+
+    renderer.domElement.addEventListener("pointerdown", handlePointerDown);
+    renderer.domElement.addEventListener("pointerup", handlePointerUp);
+    renderer.domElement.addEventListener("pointermove", handlePointerMove);
+    renderer.domElement.addEventListener("pointerleave", handlePointerLeave);
+
+    // Animation Loop
+    const animate = () => {
+      animationFrameRef.current = requestAnimationFrame(animate);
+
+      // Update Particles
+      const positions = particleGeo.attributes.position.array as Float32Array;
+      const mouse3D = new THREE.Vector3(
+        (mouseRef.current.x / renderer.domElement.clientWidth) * 2 - 1,
+        -(mouseRef.current.y / renderer.domElement.clientHeight) * 2 + 1,
+        0
+      ).unproject(camera);
+
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const pData = particleData[i];
+        const px = positions[i * 3];
+        const py = positions[i * 3 + 1];
+        const pz = positions[i * 3 + 2];
+        const pPos = new THREE.Vector3(px, py, pz);
+
+        if (mouseRef.current.isDown) {
+          const dist = pPos.distanceTo(mouse3D);
+          if (dist < 3) {
+            const vortexForce = 0.05;
+            const toMouse = new THREE.Vector3()
+              .subVectors(mouse3D, pPos)
+              .normalize();
+            const vortex = new THREE.Vector3(
+              -toMouse.y,
+              toMouse.x,
+              0
+            ).multiplyScalar(vortexForce);
+            pData.velocity.add(vortex);
+          }
+        }
+
+        pData.velocity.multiplyScalar(0.95); // Damping
+        pPos.add(pData.velocity);
+
+        if (pPos.y < -1) pPos.y = 10;
+
+        positions[i * 3] = pPos.x;
+        positions[i * 3 + 1] = pPos.y;
+        positions[i * 3 + 2] = pPos.z;
+      }
+      particleGeo.attributes.position.needsUpdate = true;
+
+      controls.update();
+      renderer.render(scene, camera);
+    };
+
+    animate();
+
+    // Resize Handler
+    const handleResize = () => {
+      if (!containerRef.current) return;
+      camera.aspect =
+        containerRef.current.clientWidth / containerRef.current.clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(
+        containerRef.current.clientWidth,
+        containerRef.current.clientHeight
+      );
+    };
+    window.addEventListener("resize", handleResize);
+
+    const container = containerRef.current;
+    // Cleanup
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      renderer.domElement.removeEventListener("pointerdown", handlePointerDown);
+      renderer.domElement.removeEventListener("pointerup", handlePointerUp);
+      renderer.domElement.removeEventListener("pointermove", handlePointerMove);
+      renderer.domElement.removeEventListener(
+        "pointerleave",
+        handlePointerLeave
+      );
+
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+
+      controls.dispose();
+      groundGeo.dispose();
+      groundMat.dispose();
+      buildingGeo.dispose();
+      buildingMat.dispose();
+      particleGeo.dispose();
+      particleMat.dispose();
+      renderer.dispose();
+
+      if (container && renderer.domElement) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return (
+    <Container ref={containerRef}>
+      <Instruction>
+        마우스를 드래그하여 먼지 소용돌이 생성
+        <br />
+        드래그하여 카메라 시점 회전
+      </Instruction>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+  cursor: grab;
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+const Instruction = styled.div`
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.4);
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-family: sans-serif;
+  pointer-events: none;
+  text-align: center;
+  z-index: 10;
+`;
+
+export default FineDustAnimation;

--- a/src/components/animation/RainAnimation.tsx
+++ b/src/components/animation/RainAnimation.tsx
@@ -186,7 +186,7 @@ const RainAnimation = ({
 // 애니메이션을 포함할 컨테이너 스타일 정의
 const Container = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
   position: relative;
   overflow: hidden;
 `;

--- a/src/components/animation/SeaLevelRiseAnimation.tsx
+++ b/src/components/animation/SeaLevelRiseAnimation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";

--- a/src/components/animation/SeaLevelRiseAnimation.tsx
+++ b/src/components/animation/SeaLevelRiseAnimation.tsx
@@ -1,0 +1,633 @@
+import React, { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+
+// --- CONFIGURATION ---
+const GRID_SIZE = 16;
+const TILE_SIZE = 1.2;
+const FLOOD_SPEED = 0.002;
+const MAX_ENERGY = 500;
+const BUILD_COST = 10;
+const WIN_WATER_LEVEL = 3.5;
+
+const PALETTE = {
+  bg: 0x050510,
+  water: 0x00aaff,
+  waterEmissive: 0x003388,
+  ground: 0x222222,
+  building: 0xffffff,
+  buildingFlooded: 0x111111,
+  wall: 0xff9900,
+  cursor: 0x00ff00,
+};
+
+interface TileData {
+  id: number;
+  x: number;
+  z: number;
+  gridX: number;
+  gridZ: number;
+  type: "GROUND" | "BUILDING" | "WALL";
+  height: number;
+  isFlooded: boolean;
+  instanceId: number;
+}
+
+const SeaLevelDefenseFinal = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const frameIdRef = useRef<number>(0);
+  const tilesRef = useRef<TileData[]>([]);
+  const waterLevelRef = useRef(-1.5);
+
+  // Game Logic Refs
+  const energyRef = useRef(MAX_ENERGY);
+  const gameStateRef = useRef<"PLAYING" | "GAME_OVER" | "VICTORY">("PLAYING");
+  const floodedCountRef = useRef(0);
+
+  // UI State
+  const [energy, setEnergy] = useState(MAX_ENERGY);
+  const [floodedCount, setFloodedCount] = useState(0);
+  const [totalBuildings, setTotalBuildings] = useState(0);
+  const [waterLevelDisplay, setWaterLevelDisplay] = useState(0);
+  const [gameState, setGameState] = useState<
+    "PLAYING" | "GAME_OVER" | "VICTORY"
+  >("PLAYING");
+
+  const mouseRef = useRef(new THREE.Vector2());
+  const raycaster = new THREE.Raycaster();
+  const interactionPlaneRef = useRef<THREE.Mesh | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // 1. Scene & Camera
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(PALETTE.bg);
+    scene.fog = new THREE.FogExp2(PALETTE.bg, 0.012);
+
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      containerRef.current.clientWidth / containerRef.current.clientHeight,
+      0.1,
+      1000
+    );
+    camera.position.set(30, 30, 20);
+
+    const renderer = new THREE.WebGLRenderer({
+      powerPreference: "high-performance",
+      antialias: false,
+    });
+    renderer.setSize(
+      containerRef.current.clientWidth,
+      containerRef.current.clientHeight
+    );
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.toneMapping = THREE.ReinhardToneMapping;
+    renderer.toneMappingExposure = 1.4;
+
+    // Canvas Positioning for Sticky UI support
+    renderer.domElement.style.position = "absolute";
+    renderer.domElement.style.top = "0";
+    renderer.domElement.style.left = "0";
+    renderer.domElement.style.zIndex = "0";
+
+    containerRef.current.appendChild(renderer.domElement);
+
+    // 2. Post-Processing
+    const composer = new EffectComposer(renderer);
+    const renderPass = new RenderPass(scene, camera);
+    const bloomPass = new UnrealBloomPass(
+      new THREE.Vector2(window.innerWidth, window.innerHeight),
+      0.8,
+      0.5,
+      0.8
+    );
+    composer.addPass(renderPass);
+    composer.addPass(bloomPass);
+
+    // 3. Lights
+    const ambientLight = new THREE.AmbientLight(0x666688, 2.0);
+    scene.add(ambientLight);
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1.2);
+    dirLight.position.set(20, 50, 20);
+    dirLight.castShadow = true;
+    scene.add(dirLight);
+
+    // 4. Interaction Plane
+    const planeGeo = new THREE.PlaneGeometry(100, 100);
+    const planeMat = new THREE.MeshBasicMaterial({ visible: false });
+    const interactionPlane = new THREE.Mesh(planeGeo, planeMat);
+    interactionPlane.rotation.x = -Math.PI / 2;
+    interactionPlane.position.y = 0.5;
+    scene.add(interactionPlane);
+    interactionPlaneRef.current = interactionPlane;
+
+    // 5. Water System
+    const tileCount = GRID_SIZE * GRID_SIZE;
+
+    // A. Outer Ocean (Infinite water with a hole for the grid)
+    const oceanShape = new THREE.Shape();
+    oceanShape.moveTo(-50, -50);
+    oceanShape.lineTo(50, -50);
+    oceanShape.lineTo(50, 50);
+    oceanShape.lineTo(-50, 50);
+    oceanShape.lineTo(-50, -50);
+
+    const holePath = new THREE.Path();
+    const halfSize = (GRID_SIZE * TILE_SIZE) / 2;
+    holePath.moveTo(-halfSize, -halfSize);
+    holePath.lineTo(halfSize, -halfSize);
+    holePath.lineTo(halfSize, halfSize);
+    holePath.lineTo(-halfSize, halfSize);
+    holePath.lineTo(-halfSize, -halfSize);
+    oceanShape.holes.push(holePath);
+
+    const oceanGeo = new THREE.ShapeGeometry(oceanShape);
+    const waterMat = new THREE.MeshStandardMaterial({
+      color: PALETTE.water,
+      transparent: true,
+      opacity: 0.8,
+      emissive: PALETTE.waterEmissive,
+      emissiveIntensity: 0.6,
+      roughness: 0.0,
+      side: THREE.DoubleSide,
+    });
+    const outerWater = new THREE.Mesh(oceanGeo, waterMat);
+    outerWater.rotation.x = -Math.PI / 2;
+    scene.add(outerWater);
+
+    // B. Inner Water (Instanced tiles for the grid)
+    const innerWaterGeo = new THREE.PlaneGeometry(TILE_SIZE, TILE_SIZE);
+    const innerWaterMesh = new THREE.InstancedMesh(
+      innerWaterGeo,
+      waterMat,
+      tileCount
+    );
+    scene.add(innerWaterMesh);
+
+    // 6. City Generation
+    const boxGeo = new THREE.BoxGeometry(TILE_SIZE * 0.95, 1, TILE_SIZE * 0.95);
+    boxGeo.translate(0, 0.5, 0);
+
+    const buildingMat = new THREE.MeshStandardMaterial({
+      color: PALETTE.building,
+      roughness: 0.3,
+    });
+    const groundMat = new THREE.MeshStandardMaterial({
+      color: PALETTE.ground,
+      roughness: 1.0,
+    });
+    const wallMat = new THREE.MeshStandardMaterial({
+      color: PALETTE.wall,
+      emissive: 0xff6600,
+      roughness: 0.5,
+    });
+
+    const buildingMesh = new THREE.InstancedMesh(
+      boxGeo,
+      buildingMat,
+      tileCount
+    );
+    const groundMesh = new THREE.InstancedMesh(boxGeo, groundMat, tileCount);
+    const wallMesh = new THREE.InstancedMesh(boxGeo, wallMat, tileCount);
+
+    scene.add(buildingMesh);
+    scene.add(groundMesh);
+    scene.add(wallMesh);
+
+    const tiles: TileData[] = [];
+    const dummy = new THREE.Object3D();
+    let bIdx = 0,
+      gIdx = 0,
+      buildingCount = 0;
+
+    // Initialize matrices
+    for (let i = 0; i < tileCount; i++) {
+      dummy.scale.set(0, 0, 0);
+      dummy.updateMatrix();
+      wallMesh.setMatrixAt(i, dummy.matrix);
+      innerWaterMesh.setMatrixAt(i, dummy.matrix); // Init inner water hidden
+    }
+
+    for (let x = 0; x < GRID_SIZE; x++) {
+      for (let z = 0; z < GRID_SIZE; z++) {
+        // [수정] Gap Fix: Center the grid properly
+        const worldX = (x - GRID_SIZE / 2 + 0.5) * TILE_SIZE;
+        const worldZ = (z - GRID_SIZE / 2 + 0.5) * TILE_SIZE;
+        const dist = Math.sqrt(worldX * worldX + worldZ * worldZ);
+
+        const isBuilding = dist < 6.5 && Math.random() > 0.35;
+        let height = Math.max(0.5, 3.0 - dist * 0.2 + Math.random() * 0.5);
+        if (!isBuilding) height = 0.5;
+
+        dummy.position.set(worldX, 0, worldZ);
+        dummy.scale.set(1, height, 1);
+        dummy.updateMatrix();
+
+        let type: "GROUND" | "BUILDING" = "GROUND";
+        let instanceId = gIdx;
+        if (isBuilding) {
+          type = "BUILDING";
+          instanceId = bIdx;
+          buildingMesh.setMatrixAt(bIdx++, dummy.matrix);
+          buildingCount++;
+        } else {
+          groundMesh.setMatrixAt(gIdx++, dummy.matrix);
+        }
+
+        tiles.push({
+          id: tiles.length,
+          x: worldX,
+          z: worldZ,
+          gridX: x,
+          gridZ: z,
+          type,
+          height,
+          isFlooded: false,
+          instanceId,
+        });
+      }
+    }
+    buildingMesh.instanceMatrix.needsUpdate = true;
+    groundMesh.instanceMatrix.needsUpdate = true;
+    wallMesh.instanceMatrix.needsUpdate = true;
+    tilesRef.current = tiles;
+    setTotalBuildings(buildingCount);
+
+    // 7. Ghost Cursor
+    const ghostGeo = new THREE.BoxGeometry(TILE_SIZE, 4, TILE_SIZE);
+    const ghostMat = new THREE.MeshBasicMaterial({
+      color: PALETTE.cursor,
+      wireframe: true,
+      transparent: true,
+      opacity: 0.5,
+      depthTest: false,
+    });
+    const ghostCursor = new THREE.Mesh(ghostGeo, ghostMat);
+    scene.add(ghostCursor);
+
+    // Controls
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.maxPolarAngle = Math.PI / 2.2;
+    controls.enableZoom = false;
+
+    // Handlers
+    const handleMouseMove = (e: MouseEvent) => {
+      if (gameStateRef.current !== "PLAYING" || !interactionPlaneRef.current)
+        return;
+      const rect = renderer.domElement.getBoundingClientRect();
+      mouseRef.current.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      mouseRef.current.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+
+      raycaster.setFromCamera(mouseRef.current, camera);
+      const intersects = raycaster.intersectObject(interactionPlaneRef.current);
+
+      if (intersects.length > 0) {
+        const p = intersects[0].point;
+        // [수정] Snap logic for centered grid
+        // Since grid is offset by 0.5 * TILE_SIZE, standard round might be off?
+        // Grid centers are at (i + 0.5) * TILE_SIZE.
+        // Let's find closest tile in tilesRef instead of math snapping for precision
+
+        // Optimization: Math snap is faster.
+        // Grid starts at -GRID_SIZE/2 * TILE_SIZE + 0.5 * TILE_SIZE
+        // = (-8 + 0.5) * 1.2 = -7.5 * 1.2 = -9.0
+        // Next is -7.8, etc.
+        // It's (n) * 1.2 where n is half-integer?
+        // Let's just use the tile finding logic for the cursor position
+
+        const closest = tilesRef.current.reduce((prev, curr) => {
+          const distPrev = (prev.x - p.x) ** 2 + (prev.z - p.z) ** 2;
+          const distCurr = (curr.x - p.x) ** 2 + (curr.z - p.z) ** 2;
+          return distCurr < distPrev ? curr : prev;
+        });
+
+        if (
+          Math.abs(closest.x - p.x) < TILE_SIZE &&
+          Math.abs(closest.z - p.z) < TILE_SIZE
+        ) {
+          ghostCursor.position.set(closest.x, 2, closest.z);
+          ghostCursor.visible = true;
+        } else {
+          ghostCursor.visible = false;
+        }
+      } else {
+        ghostCursor.visible = false;
+      }
+    };
+
+    const handleClick = () => {
+      if (gameStateRef.current !== "PLAYING" || energyRef.current < BUILD_COST)
+        return;
+      const cx = ghostCursor.position.x;
+      const cz = ghostCursor.position.z;
+
+      const target = tilesRef.current.find(
+        (t) => Math.abs(t.x - cx) < 0.1 && Math.abs(t.z - cz) < 0.1
+      );
+
+      if (target && target.type !== "WALL") {
+        energyRef.current -= BUILD_COST;
+        setEnergy(energyRef.current);
+
+        target.type = "WALL";
+        target.height += 4.0;
+        target.isFlooded = false;
+
+        // [핵심 수정] 더미 객체의 회전값 초기화! (물을 그릴 때 돌려놨던 것을 되돌림)
+        dummy.rotation.set(0, 0, 0);
+        dummy.position.set(target.x, 0, target.z);
+        dummy.scale.set(1, target.height, 1);
+        dummy.updateMatrix();
+
+        wallMesh.setMatrixAt(target.id, dummy.matrix);
+        wallMesh.instanceMatrix.needsUpdate = true;
+
+        // 물 제거
+        dummy.scale.set(0, 0, 0);
+        dummy.updateMatrix();
+        innerWaterMesh.setMatrixAt(target.id, dummy.matrix);
+        innerWaterMesh.instanceMatrix.needsUpdate = true;
+      }
+    };
+
+    renderer.domElement.addEventListener("mousemove", handleMouseMove);
+    renderer.domElement.addEventListener("mousedown", handleClick);
+
+    // Animation Loop
+    const clock = new THREE.Clock();
+    const color = new THREE.Color();
+
+    const animate = () => {
+      frameIdRef.current = requestAnimationFrame(animate);
+      const time = clock.getElapsedTime();
+
+      if (gameStateRef.current === "PLAYING") {
+        waterLevelRef.current += FLOOD_SPEED;
+        const currentWaterLevel = waterLevelRef.current;
+        const timeVal = Math.sin(time) * 0.1;
+
+        outerWater.position.y = currentWaterLevel + timeVal;
+
+        // Flood Logic
+        const tiles = tilesRef.current;
+        const flooded = new Set<number>();
+        const queue: number[] = [];
+
+        tiles.forEach((t) => {
+          t.isFlooded = false;
+          if (t.type !== "WALL") {
+            if (
+              t.gridX === 0 ||
+              t.gridX === GRID_SIZE - 1 ||
+              t.gridZ === 0 ||
+              t.gridZ === GRID_SIZE - 1
+            ) {
+              if (t.height < currentWaterLevel) {
+                flooded.add(t.id);
+                queue.push(t.id);
+              }
+            }
+          }
+        });
+
+        while (queue.length > 0) {
+          const id = queue.shift()!;
+          const t = tiles[id];
+          t.isFlooded = true;
+
+          const neighbors = [
+            tiles.find(
+              (n) => n && n.gridX === t.gridX + 1 && n.gridZ === t.gridZ
+            ),
+            tiles.find(
+              (n) => n && n.gridX === t.gridX - 1 && n.gridZ === t.gridZ
+            ),
+            tiles.find(
+              (n) => n && n.gridX === t.gridX && n.gridZ === t.gridZ + 1
+            ),
+            tiles.find(
+              (n) => n && n.gridX === t.gridX && n.gridZ === t.gridZ - 1
+            ),
+          ];
+
+          for (const n of neighbors) {
+            if (
+              n &&
+              !flooded.has(n.id) &&
+              n.type !== "WALL" &&
+              n.height < currentWaterLevel
+            ) {
+              flooded.add(n.id);
+              queue.push(n.id);
+            }
+          }
+        }
+
+        // Visuals
+        let currentFloodedCount = 0;
+
+        // Reset Inner Water
+        for (let i = 0; i < tileCount; i++) {
+          dummy.rotation.set(0, 0, 0); // 기본 회전 초기화
+          dummy.scale.set(0, 0, 0);
+          dummy.updateMatrix();
+          innerWaterMesh.setMatrixAt(i, dummy.matrix);
+        }
+
+        tiles.forEach((t) => {
+          // Building Color
+          if (t.isFlooded && t.type === "BUILDING") {
+            currentFloodedCount++;
+            buildingMesh.setColorAt(
+              t.instanceId,
+              color.setHex(PALETTE.buildingFlooded)
+            );
+          } else if (t.type === "BUILDING") {
+            buildingMesh.setColorAt(
+              t.instanceId,
+              color.setHex(PALETTE.building)
+            );
+          }
+
+          // Water Visual
+          if (t.isFlooded && t.type !== "WALL") {
+            // [주의] 물을 그리기 위해 dummy를 회전시킴 -> handleClick에서 이를 초기화해야 함
+            dummy.rotation.set(-Math.PI / 2, 0, 0);
+            dummy.position.set(t.x, currentWaterLevel + timeVal, t.z);
+            dummy.scale.set(1, 1, 1);
+            dummy.updateMatrix();
+            innerWaterMesh.setMatrixAt(t.id, dummy.matrix);
+          }
+        });
+
+        buildingMesh.instanceColor!.needsUpdate = true;
+        innerWaterMesh.instanceMatrix.needsUpdate = true;
+
+        if (currentFloodedCount !== floodedCountRef.current) {
+          floodedCountRef.current = currentFloodedCount;
+          setFloodedCount(currentFloodedCount);
+        }
+
+        // Update Water Level Display (Throttled roughly)
+        if (Math.random() < 0.1) {
+          setWaterLevelDisplay(currentWaterLevel);
+        }
+
+        // Win/Loss Check
+        if (currentFloodedCount > buildingCount * 0.7) {
+          gameStateRef.current = "GAME_OVER";
+          setGameState("GAME_OVER");
+        } else if (currentWaterLevel >= WIN_WATER_LEVEL) {
+          gameStateRef.current = "VICTORY";
+          setGameState("VICTORY");
+        }
+      }
+      controls.update();
+      composer.render();
+    };
+    animate();
+
+    const handleResize = () => {
+      if (!containerRef.current) return;
+      const w = containerRef.current.clientWidth;
+      const h = containerRef.current.clientHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+      composer.setSize(w, h);
+    };
+    window.addEventListener("resize", handleResize);
+
+    const container = containerRef.current;
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (renderer.domElement) {
+        renderer.domElement.removeEventListener("mousemove", handleMouseMove);
+        renderer.domElement.removeEventListener("mousedown", handleClick);
+      }
+      if (frameIdRef.current) cancelAnimationFrame(frameIdRef.current);
+      renderer.dispose();
+      composer.dispose();
+      planeGeo.dispose();
+      planeMat.dispose();
+      oceanGeo.dispose();
+      innerWaterGeo.dispose();
+      waterMat.dispose();
+      boxGeo.dispose();
+      ghostGeo.dispose();
+      ghostMat.dispose();
+      buildingMat.dispose();
+      groundMat.dispose();
+      wallMat.dispose();
+      if (container && renderer.domElement)
+        container.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return (
+    <Container ref={containerRef}>
+      <MinimalUI>
+        <StatItem>ENERGY: {energy}</StatItem>
+        <StatItem $danger={floodedCount > 0}>
+          FLOODED: {floodedCount} / {Math.floor(totalBuildings * 0.7)}
+        </StatItem>
+        <StatItem>LEVEL: {(waterLevelDisplay + 1.5).toFixed(2)}m</StatItem>
+
+        {gameState === "PLAYING" && <Guide>Click to build Sea Wall</Guide>}
+
+        {gameState === "GAME_OVER" && (
+          <>
+            <StatusText $color="#ff4444">CITY LOST</StatusText>
+            <TextButton onClick={() => window.location.reload()}>
+              TRY AGAIN
+            </TextButton>
+          </>
+        )}
+
+        {gameState === "VICTORY" && (
+          <>
+            <StatusText $color="#00ffaa">CITY SAVED</StatusText>
+            <TextButton onClick={() => window.location.reload()}>
+              PLAY AGAIN
+            </TextButton>
+          </>
+        )}
+      </MinimalUI>
+    </Container>
+  );
+};
+
+// Styles
+const Container = styled.div`
+  width: 100%;
+  height: 100vh;
+  background: #050510;
+  overflow: hidden;
+  position: relative; /* For absolute canvas and sticky UI */
+`;
+
+const MinimalUI = styled.div`
+  position: sticky;
+  top: 30px;
+  left: 30px;
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  font-family: "Inter", sans-serif;
+  color: #fff;
+  user-select: none;
+  pointer-events: none;
+  z-index: 10;
+  padding: 20px; /* Add padding to ensure it's not too close to edge */
+`;
+
+const StatItem = styled.div<{ $danger?: boolean }>`
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: ${(props) => (props.$danger ? "#ff4444" : "#ffffff")};
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+`;
+
+const Guide = styled.div`
+  font-size: 0.8rem;
+  color: #aaa;
+  margin-top: 10px;
+`;
+
+const StatusText = styled.div<{ $color: string }>`
+  font-size: 1.5rem;
+  font-weight: 900;
+  letter-spacing: 2px;
+  color: ${(props) => props.$color};
+  margin-top: 20px;
+  text-shadow: 0 0 10px ${(props) => props.$color};
+`;
+
+const TextButton = styled.button`
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: bold;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  pointer-events: auto;
+  text-decoration: underline;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+  &:hover {
+    opacity: 1;
+    color: #00ffaa;
+  }
+`;
+
+export default SeaLevelDefenseFinal;

--- a/src/components/animation/WildfireAnimation.tsx
+++ b/src/components/animation/WildfireAnimation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
@@ -51,7 +51,6 @@ const SlowBurnWildfire = () => {
     // 1. Scene
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(PALETTE.bg);
-    scene.fog = new THREE.FogExp2(PALETTE.bg, 0.03);
 
     const camera = new THREE.PerspectiveCamera(
       50,
@@ -59,7 +58,7 @@ const SlowBurnWildfire = () => {
       0.1,
       1000
     );
-    camera.position.set(-20, 20, 20); // 줌인 상태 유지
+    camera.position.set(-30, 30, 30); // 줌인 상태 유지
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({
@@ -191,6 +190,7 @@ const SlowBurnWildfire = () => {
     controls.enableDamping = true;
     const raycaster = new THREE.Raycaster();
     const mouse = new THREE.Vector2();
+    controls.enableZoom = false;
 
     const onMouseDown = (e: MouseEvent) =>
       (mouseStart.current = { x: e.clientX, y: e.clientY });
@@ -381,12 +381,13 @@ const SlowBurnWildfire = () => {
 
 const Container = styled.div`
   width: 100%;
-  height: 100%;
-  background: #000;
+  height: 100vh;
   overflow: hidden;
+  position: relative; /* For absolute canvas and sticky UI */
 `;
+
 const StatusPanel = styled.div`
-  position: absolute;
+  position: sticky;
   top: 50%;
   left: 20px;
   transform: translateY(-50%);
@@ -395,6 +396,7 @@ const StatusPanel = styled.div`
   gap: 8px;
   pointer-events: none;
 `;
+
 const StatusItem = styled.div<{ color: string }>`
   font-family: monospace;
   font-weight: bold;

--- a/src/components/animation/WildfireAnimation.tsx
+++ b/src/components/animation/WildfireAnimation.tsx
@@ -1,0 +1,406 @@
+import React, { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+
+// --- SLOW BURN CONFIG ---
+const CONFIG = {
+  gridSize: 30,
+  treeDensity: 0.6,
+  burnSpeed: 0.7,
+  spreadRadius: 3.2,
+  spreadChance: 0.5,
+  waterRadius: 5, // 물 범위
+};
+
+const PALETTE = {
+  bg: 0x050510,
+  ground: 0x0a0a15,
+  healthy: 0x00ffaa, // Mint
+  burning: 0xff5500, // Orange
+  burnt: 0x111111, // Dark Grey
+  ember: 0xffcc00, // Gold
+  water: 0x00ffff, // Cyan
+};
+
+interface TreeData {
+  id: number;
+  x: number;
+  z: number;
+  state: "HEALTHY" | "BURNING" | "BURNT";
+  hp: number;
+  maxHp: number;
+  scaleY: number;
+  flashOffset: number;
+}
+
+const SlowBurnWildfire = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const frameIdRef = useRef<number>(0);
+  const treesRef = useRef<TreeData[]>([]);
+
+  const [stats, setStats] = useState({ healthy: 0, burning: 0, burnt: 0 });
+  const mouseStart = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // 1. Scene
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(PALETTE.bg);
+    scene.fog = new THREE.FogExp2(PALETTE.bg, 0.03);
+
+    const camera = new THREE.PerspectiveCamera(
+      50,
+      containerRef.current.clientWidth / containerRef.current.clientHeight,
+      0.1,
+      1000
+    );
+    camera.position.set(-20, 20, 20); // 줌인 상태 유지
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({
+      powerPreference: "high-performance",
+      antialias: false,
+    });
+    renderer.setSize(
+      containerRef.current.clientWidth,
+      containerRef.current.clientHeight
+    );
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.toneMapping = THREE.ReinhardToneMapping;
+    containerRef.current.appendChild(renderer.domElement);
+
+    // 2. Bloom (은은하게)
+    const composer = new EffectComposer(renderer);
+    composer.addPass(new RenderPass(scene, camera));
+    composer.addPass(
+      new UnrealBloomPass(
+        new THREE.Vector2(window.innerWidth, window.innerHeight),
+        1.5, // 강도 적절히
+        0.4,
+        0.1
+      )
+    );
+
+    // 3. Environment
+    scene.add(new THREE.AmbientLight(0x333355, 1.0));
+    const dirLight = new THREE.DirectionalLight(0xaaccff, 0.5);
+    dirLight.position.set(10, 20, 10);
+    scene.add(dirLight);
+
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(CONFIG.gridSize * 2, CONFIG.gridSize * 2),
+      new THREE.MeshStandardMaterial({ color: PALETTE.ground, roughness: 0.8 })
+    );
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = -0.5;
+    scene.add(ground);
+
+    const gridHelper = new THREE.GridHelper(
+      CONFIG.gridSize * 2,
+      CONFIG.gridSize,
+      0x333366,
+      0x111122
+    );
+    gridHelper.position.y = -0.45;
+    scene.add(gridHelper);
+
+    // 4. Trees
+    const treeCount = Math.floor(
+      CONFIG.gridSize * CONFIG.gridSize * CONFIG.treeDensity
+    );
+    const treeGeo = new THREE.BoxGeometry(0.6, 1, 0.6);
+    treeGeo.translate(0, 0.5, 0);
+    const treeMesh = new THREE.InstancedMesh(
+      treeGeo,
+      new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4 }),
+      treeCount
+    );
+    scene.add(treeMesh);
+
+    // Init
+    const dummy = new THREE.Object3D();
+    const color = new THREE.Color();
+    const trees: TreeData[] = [];
+    let idx = 0;
+
+    for (let x = -CONFIG.gridSize / 2; x < CONFIG.gridSize / 2; x++) {
+      for (let z = -CONFIG.gridSize / 2; z < CONFIG.gridSize / 2; z++) {
+        if (Math.random() > CONFIG.treeDensity) continue;
+        if (idx >= treeCount) break;
+
+        const h = 0.6 + Math.random() * 1.4;
+        dummy.position.set(x, 0, z);
+        dummy.scale.set(1, h, 1);
+        dummy.updateMatrix();
+        treeMesh.setMatrixAt(idx, dummy.matrix);
+        treeMesh.setColorAt(idx, color.setHex(PALETTE.healthy));
+
+        // 중앙 발화
+        const isFire = Math.sqrt(x * x + z * z) < 2.5;
+
+        trees.push({
+          id: idx,
+          x,
+          z,
+          state: isFire ? "BURNING" : "HEALTHY",
+          hp: 100,
+          maxHp: 100,
+          scaleY: h,
+          flashOffset: Math.random() * 100,
+        });
+        idx++;
+      }
+    }
+    treeMesh.instanceMatrix.needsUpdate = true;
+    treeMesh.instanceColor!.needsUpdate = true;
+    treesRef.current = trees;
+
+    // 5. Particles
+    const pCount = 1000;
+    const pMesh = new THREE.InstancedMesh(
+      new THREE.BoxGeometry(0.1, 0.1, 0.1),
+      new THREE.MeshBasicMaterial({ color: PALETTE.ember }),
+      pCount
+    );
+    scene.add(pMesh);
+    const pData = Array.from({ length: pCount }, () => ({
+      active: false,
+      pos: new THREE.Vector3(0, -100, 0),
+      vel: new THREE.Vector3(),
+      life: 0,
+    }));
+
+    // 6. Water Ring
+    const ringMat = new THREE.MeshBasicMaterial({
+      color: PALETTE.water,
+      transparent: true,
+      opacity: 0,
+      side: THREE.DoubleSide,
+    });
+    const ring = new THREE.Mesh(new THREE.RingGeometry(0.5, 0.8, 32), ringMat);
+    ring.rotation.x = -Math.PI / 2;
+    scene.add(ring);
+
+    // Interaction
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
+    const onMouseDown = (e: MouseEvent) =>
+      (mouseStart.current = { x: e.clientX, y: e.clientY });
+    const onMouseUp = (e: MouseEvent) => {
+      if (
+        Math.hypot(
+          e.clientX - mouseStart.current.x,
+          e.clientY - mouseStart.current.y
+        ) < 5
+      )
+        extinguish(e);
+    };
+
+    const extinguish = (e: MouseEvent) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObjects([ground, treeMesh]);
+
+      if (intersects.length > 0) {
+        const pt = intersects[0].point;
+        ring.position.copy(pt);
+        ring.position.y = 1;
+        ringMat.opacity = 1;
+        ring.scale.set(1, 1, 1);
+
+        treesRef.current.forEach((t) => {
+          if ((t.x - pt.x) ** 2 + (t.z - pt.z) ** 2 < CONFIG.waterRadius ** 2) {
+            // 회복 시 완전히 회복
+            if (t.state !== "HEALTHY") {
+              t.state = "HEALTHY";
+              t.hp = t.maxHp;
+            }
+          }
+        });
+      }
+    };
+
+    renderer.domElement.addEventListener("mousedown", onMouseDown);
+    renderer.domElement.addEventListener("mouseup", onMouseUp);
+
+    // Animation Loop
+    const clock = new THREE.Clock();
+
+    const animate = () => {
+      frameIdRef.current = requestAnimationFrame(animate);
+      const time = clock.getElapsedTime();
+      let h = 0,
+        b = 0,
+        d = 0;
+
+      const activeTrees = treesRef.current;
+
+      for (let i = 0; i < activeTrees.length; i++) {
+        const t = activeTrees[i];
+
+        if (t.state === "HEALTHY") h++;
+        else if (t.state === "BURNING") {
+          b++;
+          t.hp -= CONFIG.burnSpeed; // 천천히 탐
+
+          // [핵심] Slow & Steady Spread Logic
+          // 매 프레임 작은 확률(2%)로 전파 시도 -> 하지만 나무가 오래 타므로 결국엔 전파됨
+          if (Math.random() < CONFIG.spreadChance) {
+            // 랜덤 타겟팅
+            const targetIdx = Math.floor(Math.random() * activeTrees.length);
+            const target = activeTrees[targetIdx];
+            if (target.state === "HEALTHY") {
+              const distSq = (t.x - target.x) ** 2 + (t.z - target.z) ** 2;
+              if (distSq < CONFIG.spreadRadius ** 2) {
+                target.state = "BURNING";
+              }
+            }
+          }
+
+          if (t.hp <= 0) t.state = "BURNT";
+        } else {
+          d++;
+        }
+
+        // Visuals
+        const dummyScale = new THREE.Vector3();
+        if (t.state === "BURNING") {
+          // 부드러운 깜빡임
+          const pulse = Math.sin(time * 3 + t.flashOffset) * 0.5 + 0.5;
+          color.setHex(PALETTE.burning);
+          color.r += 0.5 * pulse;
+          color.g += 0.3 * pulse;
+
+          dummyScale.set(1.05, t.scaleY * 1.05, 1.05);
+
+          // Particles (적당히)
+          if (Math.random() < 0.05) {
+            const p = pData.find((pd) => !pd.active);
+            if (p) {
+              p.active = true;
+              p.life = 1.2;
+              p.pos.set(t.x, t.scaleY, t.z);
+              p.vel.set(
+                (Math.random() - 0.5) * 0.03,
+                0.04 + Math.random() * 0.04,
+                (Math.random() - 0.5) * 0.03
+              );
+            }
+          }
+        } else if (t.state === "BURNT") {
+          color.setHex(PALETTE.burnt);
+          dummyScale.set(0.9, t.scaleY * 0.8, 0.9);
+        } else {
+          color.setHex(PALETTE.healthy);
+          dummyScale.set(1, t.scaleY, 1);
+        }
+        treeMesh.setColorAt(i, color);
+        dummy.position.set(t.x, 0, t.z);
+        dummy.scale.copy(dummyScale);
+        dummy.updateMatrix();
+        treeMesh.setMatrixAt(i, dummy.matrix);
+      }
+      treeMesh.instanceColor!.needsUpdate = true;
+      treeMesh.instanceMatrix.needsUpdate = true;
+      setStats({ healthy: h, burning: b, burnt: d });
+
+      // Particles Update
+      for (let i = 0; i < pCount; i++) {
+        const p = pData[i];
+        if (p.active) {
+          p.life -= 0.015;
+          p.pos.add(p.vel);
+          dummy.position.copy(p.pos);
+          dummy.scale.set(p.life * 0.15, p.life * 0.15, p.life * 0.15);
+          dummy.updateMatrix();
+          pMesh.setMatrixAt(i, dummy.matrix);
+          if (p.life <= 0) {
+            p.active = false;
+            dummy.scale.set(0, 0, 0);
+            pMesh.setMatrixAt(i, dummy.matrix);
+          }
+        }
+      }
+      pMesh.instanceMatrix.needsUpdate = true;
+
+      // Ring Animation
+      if (ringMat.opacity > 0) {
+        ring.scale.multiplyScalar(1.05);
+        ringMat.opacity -= 0.03;
+      }
+
+      controls.update();
+      composer.render();
+    };
+
+    animate();
+
+    const handleResize = () => {
+      if (!containerRef.current) return;
+      const w = containerRef.current.clientWidth;
+      const h = containerRef.current.clientHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+      composer.setSize(w, h);
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      renderer.domElement.removeEventListener("mousedown", onMouseDown);
+      renderer.domElement.removeEventListener("mouseup", onMouseUp);
+      cancelAnimationFrame(frameIdRef.current);
+      renderer.dispose();
+      composer.dispose();
+      treeGeo.dispose();
+      treeMesh.dispose();
+    };
+  }, []);
+
+  return (
+    <Container ref={containerRef}>
+      <StatusPanel>
+        <StatusItem color="#00ffcc">LIVE {stats.healthy}</StatusItem>
+        <StatusItem color="#ff5500">FIRE {stats.burning}</StatusItem>
+        <StatusItem color="#666">DEAD {stats.burnt}</StatusItem>
+      </StatusPanel>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  background: #000;
+  overflow: hidden;
+`;
+const StatusPanel = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 20px;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+`;
+const StatusItem = styled.div<{ color: string }>`
+  font-family: monospace;
+  font-weight: bold;
+  font-size: 13px;
+  color: ${(p) => p.color};
+  letter-spacing: 1px;
+`;
+
+export default SlowBurnWildfire;

--- a/src/components/common/header/FilterBar.tsx
+++ b/src/components/common/header/FilterBar.tsx
@@ -1,25 +1,21 @@
-import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { rowFlex } from "../../../styles/flexStyles";
 import { useSearchParams } from "react-router-dom";
 import { climateIcons } from "../../../constants/climateIcons";
+import { Climate } from "../../../types/climate";
 
 const FilterBar = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialFilter = searchParams.get("filter");
-  const [activeFilter, setActiveFilter] = useState<string | null>(
-    initialFilter
-  );
+  const currentFilter = searchParams.get("filter");
 
-  useEffect(() => {
-    const newParams = new URLSearchParams(searchParams);
-    if (activeFilter) {
-      newParams.set("filter", activeFilter);
+  const handleFilterClick = (id: Climate) => {
+    if (currentFilter === id) {
+      searchParams.delete("filter");
+      setSearchParams(searchParams);
     } else {
-      newParams.delete("filter");
+      setSearchParams({ filter: id });
     }
-    setSearchParams(newParams);
-  }, [activeFilter]);
+  };
 
   return (
     <FilterContainer>
@@ -27,8 +23,8 @@ const FilterBar = () => {
         return (
           <IconWrapper
             key={id}
-            $active={activeFilter === id}
-            onClick={() => setActiveFilter(activeFilter === id ? null : id)}
+            $active={currentFilter === id}
+            onClick={() => handleFilterClick(id)}
           >
             <Icon />
           </IconWrapper>

--- a/src/components/earth/Warning.tsx
+++ b/src/components/earth/Warning.tsx
@@ -48,7 +48,7 @@ const Warning = ({ pin, onHoverChange }: WarningProps) => {
       <IconWrapper
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={() => navigate(`news-detail/${pin.newsId}`)}
+        onClick={() => navigate(`news-detail/${pin.newsId}?filter=${climate}`)}
       >
         <GlowLayer />
         <WarningIconStyled />

--- a/src/components/news/NewsContents.tsx
+++ b/src/components/news/NewsContents.tsx
@@ -41,15 +41,17 @@ const NewsContents = ({ newsData }: NewsContentsProps) => {
               {regionList.map((region, index) => (
                 <LocationText key={`region-${index}`}>{region}</LocationText>
               ))}
-              {climateList.map((climate, index) => (
-                <ClimateTag
-                  key={`climate-${index}`}
-                  $isActive={currentFilter === climate}
-                  onClick={() => handleClimateClick(climate)}
-                >
-                  {climate}
-                </ClimateTag>
-              ))}
+              <ClimateTagContainer>
+                {climateList.map((climate, index) => (
+                  <ClimateTag
+                    key={`climate-${index}`}
+                    $isActive={currentFilter === climate}
+                    onClick={() => handleClimateClick(climate)}
+                  >
+                    {climate}
+                  </ClimateTag>
+                ))}
+              </ClimateTagContainer>
             </TagContainer>
           </LocationContainer>
         </HeaderContainer>
@@ -102,7 +104,14 @@ const LocationText = styled.div`
 
 const TagContainer = styled.div`
   gap: 10px;
-  ${rowFlex({ justify: "center", align: "center" })}
+  width: 100%;
+  ${rowFlex({ justify: "space", align: "center" })}
+`;
+
+const ClimateTagContainer = styled.div`
+  gap: 10px;
+  width: 100%;
+  ${rowFlex({ justify: "end", align: "center" })}
 `;
 
 const ClimateTag = styled.div<{ $isActive: boolean }>`

--- a/src/components/news/NewsContents.tsx
+++ b/src/components/news/NewsContents.tsx
@@ -71,7 +71,6 @@ const NewsContents = ({ newsData }: NewsContentsProps) => {
 
 const PageLayout = styled.div`
   width: 100%;
-  height: 100%;
   gap: 10px;
   ${rowFlex({ justify: "center", align: "start" })}
 `;
@@ -79,7 +78,6 @@ const PageLayout = styled.div`
 const Container = styled.article`
   flex: 7;
   padding: 30px 50px;
-  height: 100%;
   ${colFlex({ align: "center" })}
 `;
 

--- a/src/components/news/NewsContents.tsx
+++ b/src/components/news/NewsContents.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { colFlex, rowFlex } from "../../styles/flexStyles";
 import theme from "../../styles/theme";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import NewsSideBar from "./NewsSideBar";
 
 interface NewsContentsProps {
@@ -10,6 +10,9 @@ interface NewsContentsProps {
 
 const NewsContents = ({ newsData }: NewsContentsProps) => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentFilter = searchParams.get("filter");
+
   const {
     climateList,
     regionList,
@@ -21,6 +24,10 @@ const NewsContents = ({ newsData }: NewsContentsProps) => {
     aiSolution,
     aiRelated,
   } = newsData;
+
+  const handleClimateClick = (climate: string) => {
+    setSearchParams({ filter: climate });
+  };
 
   return (
     <PageLayout>
@@ -35,7 +42,13 @@ const NewsContents = ({ newsData }: NewsContentsProps) => {
                 <LocationText key={`region-${index}`}>{region}</LocationText>
               ))}
               {climateList.map((climate, index) => (
-                <ClimateTag key={`climate-${index}`}>{climate}</ClimateTag>
+                <ClimateTag
+                  key={`climate-${index}`}
+                  $isActive={currentFilter === climate}
+                  onClick={() => handleClimateClick(climate)}
+                >
+                  {climate}
+                </ClimateTag>
               ))}
             </TagContainer>
           </LocationContainer>
@@ -82,9 +95,9 @@ const LocationContainer = styled.div`
 
 const LocationText = styled.div`
   font-size: 18px;
-  background-color: ${theme.colors.primary};
   padding: 5px 10px;
   border-radius: 15px;
+  border: 1px solid ${theme.colors.white};
 `;
 
 const TagContainer = styled.div`
@@ -92,12 +105,19 @@ const TagContainer = styled.div`
   ${rowFlex({ justify: "center", align: "center" })}
 `;
 
-const ClimateTag = styled.div`
+const ClimateTag = styled.div<{ $isActive: boolean }>`
   font-size: 18px;
-  background-color: ${theme.colors.secondary};
+  background-color: ${({ $isActive }) => $isActive && theme.colors.primary};
   padding: 5px 10px;
   border-radius: 15px;
+  border: 1px solid ${theme.colors.primary};
   color: ${theme.colors.textPrimary};
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: ${theme.colors.primary};
+  }
 `;
 
 const NavigationArrow = styled.div`

--- a/src/constants/climateMap.tsx
+++ b/src/constants/climateMap.tsx
@@ -3,8 +3,11 @@ import DroughtAnimation from "../components/animation/DroughtAnimation";
 import FineDustAnimation from "../components/animation/FineDustAnimation";
 import { Climate } from "../types/climate";
 
+import EarthquakeAnimation from "../components/animation/EarthquakeAnimation";
+
 export const climateMap: Partial<Record<Climate, React.ReactNode>> = {
   HEAVY_RAIN_OR_FLOOD: <RainAnimation dropNum={400} />,
   DROUGHT_OR_DESERTIFICATION: <DroughtAnimation />,
   FINE_DUST: <FineDustAnimation />,
+  EARTHQUAKE: <EarthquakeAnimation />,
 };

--- a/src/constants/climateMap.tsx
+++ b/src/constants/climateMap.tsx
@@ -2,8 +2,9 @@ import RainAnimation from "../components/animation/RainAnimation";
 import DroughtAnimation from "../components/animation/DroughtAnimation";
 import FineDustAnimation from "../components/animation/FineDustAnimation";
 import EarthquakeAnimation from "../components/animation/EarthquakeAnimation";
-import { Climate } from "../types/climate";
 import WildfireAnimation from "../components/animation/WildfireAnimation";
+import { Climate } from "../types/climate";
+import SeaLevelRiseAnimation from "../components/animation/SeaLevelRiseAnimation";
 
 export const climateMap: Partial<Record<Climate, React.ReactNode>> = {
   HEAVY_RAIN_OR_FLOOD: <RainAnimation dropNum={400} />,
@@ -11,4 +12,5 @@ export const climateMap: Partial<Record<Climate, React.ReactNode>> = {
   FINE_DUST: <FineDustAnimation />,
   EARTHQUAKE: <EarthquakeAnimation />,
   WILDFIRE: <WildfireAnimation />,
+  SEA_LEVEL_RISE: <SeaLevelRiseAnimation />,
 };

--- a/src/constants/climateMap.tsx
+++ b/src/constants/climateMap.tsx
@@ -1,13 +1,14 @@
 import RainAnimation from "../components/animation/RainAnimation";
 import DroughtAnimation from "../components/animation/DroughtAnimation";
 import FineDustAnimation from "../components/animation/FineDustAnimation";
-import { Climate } from "../types/climate";
-
 import EarthquakeAnimation from "../components/animation/EarthquakeAnimation";
+import { Climate } from "../types/climate";
+import WildfireAnimation from "../components/animation/WildfireAnimation";
 
 export const climateMap: Partial<Record<Climate, React.ReactNode>> = {
   HEAVY_RAIN_OR_FLOOD: <RainAnimation dropNum={400} />,
   DROUGHT_OR_DESERTIFICATION: <DroughtAnimation />,
   FINE_DUST: <FineDustAnimation />,
   EARTHQUAKE: <EarthquakeAnimation />,
+  WILDFIRE: <WildfireAnimation />,
 };

--- a/src/constants/climateMap.tsx
+++ b/src/constants/climateMap.tsx
@@ -1,8 +1,10 @@
 import RainAnimation from "../components/animation/RainAnimation";
 import DroughtAnimation from "../components/animation/DroughtAnimation";
+import FineDustAnimation from "../components/animation/FineDustAnimation";
 import { Climate } from "../types/climate";
 
 export const climateMap: Partial<Record<Climate, React.ReactNode>> = {
   HEAVY_RAIN_OR_FLOOD: <RainAnimation dropNum={400} />,
   DROUGHT_OR_DESERTIFICATION: <DroughtAnimation />,
+  FINE_DUST: <FineDustAnimation />,
 };

--- a/src/pages/NewsDetail.tsx
+++ b/src/pages/NewsDetail.tsx
@@ -4,17 +4,19 @@ import { colFlex, rowFlex } from "../styles/flexStyles";
 import NewsContents from "../components/news/NewsContents";
 import ChatPanel from "../components/chat/ChatPanel";
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { useNewsContentsQuery } from "../hooks/useNewsQuery";
 import { climateMap } from "../constants/climateMap";
 import { Climate } from "../types/climate";
 
 const NewsDetail = () => {
+  const [searchParams] = useSearchParams();
+  const filterParam = searchParams.get("filter") as Climate;
   const newsId = Number(useParams().newsId) || 1;
   const { data: response } = useNewsContentsQuery(newsId);
   const [isChatOpen, setIsChatOpen] = useState(true);
 
-  const climate = response?.data.climateList[0] as Climate;
+  const climate = filterParam ?? (response?.data.climateList[0] as Climate);
   const animation = climateMap[climate] || <RainAnimation dropNum={400} />;
 
   return (

--- a/src/pages/NewsDetail.tsx
+++ b/src/pages/NewsDetail.tsx
@@ -14,7 +14,7 @@ const NewsDetail = () => {
   const filterParam = searchParams.get("filter") as Climate;
   const newsId = Number(useParams().newsId) || 1;
   const { data: response } = useNewsContentsQuery(newsId);
-  const [isChatOpen, setIsChatOpen] = useState(true);
+  const [isChatOpen, setIsChatOpen] = useState(false);
 
   const climate = filterParam ?? (response?.data.climateList[0] as Climate);
   const animation = climateMap[climate] || <RainAnimation dropNum={400} />;
@@ -33,20 +33,21 @@ const NewsDetail = () => {
 const Container = styled.div`
   padding-top: 82px;
   width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.4);
+  height: 100vh;
   ${colFlex({ justify: "start", align: "center" })}
+  overflow-y: auto;
+  scroll-behavior: smooth;
 `;
 
 const AnimationWrapper = styled.div`
   width: 100%;
-  height: 400px;
+  flex-shrink: 0;
 `;
 
 const ContentsContainer = styled.section`
   width: 100%;
-  height: 60%;
-  ${rowFlex({ justify: "space", align: "center" })}
+  min-height: 100vh;
+  ${rowFlex({ justify: "center", align: "start" })}
 `;
 
 export default NewsDetail;


### PR DESCRIPTION
## 구현 사항

- 인터랙티브 기후 애니메이션 4종 추가: 지진, 산불, 해수면 상승, 미세먼지 시나리오를 시각화하고 사용자와 상호작용할 수 있는 3D 애니메이션을 구현했습니다.
- 뉴스 상세 페이지(NewsDetail) 레이아웃 개편: 애니메이션이 화면 전체(100vh)를 차지하도록 변경하고, 스크롤을 통해 뉴스 콘텐츠를 볼 수 있도록 개선했습니다.
- 필터 로직 리팩토링: FilterBar가 내부 상태 대신 URL 쿼리 파라미터를 사용하도록 변경하여 공유 가능한 링크를 지원합니다.

### 지진
<img width="1469" height="715" alt="스크린샷 2025-11-22 오후 11 25 35" src="https://github.com/user-attachments/assets/299f27f6-cc59-40f7-9797-594fc8004ff8" />

### 산불
<img width="1468" height="650" alt="스크린샷 2025-11-22 오후 11 24 57" src="https://github.com/user-attachments/assets/04f907fe-cb72-4067-9332-61f458ee8c07" />

### 해수면 상승
<img width="1461" height="714" alt="스크린샷 2025-11-22 오후 11 25 11" src="https://github.com/user-attachments/assets/20d4926b-ac36-48e8-9abb-f1189abb7219" />

### 미세먼지
<img width="1464" height="714" alt="스크린샷 2025-11-22 오후 11 25 22" src="https://github.com/user-attachments/assets/2c245565-b01f-469c-916f-18ba5e6c04b8" />

## 🚀 로직 설명 및 코드 설명


#### SeaLevelRiseAnimation.tsx
- BFS(너비 우선 탐색) 알고리즘을 사용하여 물이 퍼지는 로직을 구현했습니다. 방벽(WALL)이 있으면 물이 막히며, 도시의 70% 이상이 잠기면 게임 오버, 일정 수위까지 버티면 승리하는 미니게임 형식을 도입했습니다.
InstancedMesh를 사용하여 수많은 타일과 건물을 효율적으로 렌더링했습니다.
#### WildfireAnimation.tsx
- 마우스 위치에 따라 물을 뿌리는 효과를 구현하고, 불 입자(Points)와의 거리를 계산하여 불을 끄는 인터랙션을 추가했습니다.
#### NewsDetail.tsx
- AnimationWrapper와 ContentsContainer의 스타일을 수정하여 스크롤 기반의 몰입형 레이아웃을 구성했습니다.
#### FilterBar.tsx
- useSearchParams 훅을 사용하여 필터 상태를 URL과 동기화했습니다.

## 연관된 이슈

- #49 

## 🤔고민 사항

- 성능 최적화: SeaLevelRiseAnimation에서 매 프레임마다 홍수 시뮬레이션을 돌리는 것은 비용이 크므로, 최적화를 위해 상태 변경 시에만 연산하도록 useRef와 조건문을 활용했습니다.
- 스크롤 간섭: 3D 캔버스 위에서 스크롤 시 페이지가 넘어가지 않고 카메라가 줌인/아웃되는 문제를 해결하기 위해 모든 애니메이션의 OrbitControls.enableZoom을 false로 설정했습니다.
